### PR TITLE
Dont trust all proxies

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -12,6 +12,7 @@ import (
 
 func paveRoutes() *gin.Engine {
 	r := gin.Default()
+	r.SetTrustedProxies(nil)
 	docs.SwaggerInfo.BasePath = "/api/v1"
 	v1 := r.Group("/api/v1")
 


### PR DESCRIPTION
Previously, gin issued a warning on startup that the app is allowing all proxies. For now, distrust all proxies until there is a need for it.

This would be something to leverage if/when we need to use a load balancer, but this seems unlikely as this application is not currently intended for large-scale use.